### PR TITLE
Stop printing in the autoloader

### DIFF
--- a/OnAppInit.php
+++ b/OnAppInit.php
@@ -29,33 +29,15 @@ if( ! defined( 'ONAPP_WRAPPER_ROOT_DIR' ) ) {
 		$path = explode( '_', $path );
 		$path = ONAPP_WRAPPER_ROOT_DIR . implode( DIRECTORY_SEPARATOR, $path ) . '.php';
 
-		if( ! file_exists( $path ) ) {
-			if( IS_CLI ) {
-				echo '[ AUTOLOAD ]    File ' . $path . ' does not exist or can not be read';
-			}
-			else {
-				//todo add loging instead of printing
-			}
-
-			return false;
-		}
-		else {
+		if(file_exists( $path ) ) {
 			require $path;
-
-			if( ! class_exists( $className ) ) {
-				if( IS_CLI ) {
-					echo '[ AUTOLOAD ]    File ' . $path . ' does not exist or can not be read';
-				}
-				else {
-					//todo add loging instead of printing
-				}
-
-				return false;
-			}
-			else {
+	
+			if( class_exists( $className ) ) {
 				return true;
 			}
+			//todo add loging instead of printing
 		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
When running an app in CLI the autoloader outputs messages when it cannot find a file/class, this is not ideal when you have multiple registered autoloaders and another one can successfully find it.
